### PR TITLE
Sets up browser testing and phantomjs testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ figwheel_server.log
 \#*\#
 .\#*
 .nrepl-port
+out

--- a/project.clj
+++ b/project.clj
@@ -10,20 +10,42 @@
   :dependencies []
   
   :plugins [[lein-figwheel "0.5.8"]
-            [cider/cider-nrepl "0.14.0"]]
+            [cider/cider-nrepl "0.14.0"]
+            [lein-doo "0.1.7"]
+            [lein-cljsbuild "1.1.5" :exclusions [[org.clojure/clojure]]]]
   
   :clean-targets ^{:protect false} [:target-path "resources/public/cljs"]
   
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.clojure/clojurescript "1.9.293"]
                                   [com.cemerick/piggieback "0.2.1"]
-                                  [figwheel-sidecar "0.5.8"]]}}
+                                  [figwheel-sidecar "0.5.8"]
+                                  [lein-doo "0.1.7"]
+                                  [devcards "0.2.2"]]}}
   
-  :cljsbuild {:builds [{:id "dev"
+  :cljsbuild {:test-commands {"test" ["lein" "doo" "phantom" "test" "once"]}
+              
+              :builds [{:id "dev"
                         :source-paths ["src"]
                         :figwheel true
                         :compiler {:main "dandy-roll.core"
                                    :output-to "resources/public/cljs/main.js"
                                    :output-dir "resources/public/cljs/out"
-                                   :asset-path "cljs/out"}
-                       }]})
+                                   :asset-path "cljs/out"}}
+                       
+                       {:id "test"
+                        :source-paths ["src" "test"]
+                        :compiler {:main runners.doo
+                                   :optimizations :none
+                                   :output-to "resources/public/cljs/tests/all-tests.js"}}
+
+                       {:id "devcards-test"
+                        :source-paths ["src" "test"]
+                        :figwheel {:devcards true}
+                        :compiler {:main runners.browser
+                                   :optimizations :none
+                                   :asset-path "cljs/tests/out"
+                                   :output-dir "resources/public/cljs/tests/out"
+                                   :output-to "resources/public/cljs/tests/all-tests.js"
+                                   :source-map-timestamp true}}]
+              })

--- a/resources/public/tests.html
+++ b/resources/public/tests.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Tests</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <script src="cljs/tests/all-tests.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/test/dandy_roll/blob.cljs
+++ b/test/dandy_roll/blob.cljs
@@ -1,0 +1,7 @@
+(ns dandy-roll.core-test
+  (:require [cljs.test :refer-macros [is testing]]
+            [devcards.core :refer-macros [deftest]]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 1 1))))

--- a/test/runners/browser.cljs
+++ b/test/runners/browser.cljs
@@ -1,0 +1,2 @@
+(ns runners.browser
+  (:require [runners.tests]))

--- a/test/runners/doo.cljs
+++ b/test/runners/doo.cljs
@@ -1,0 +1,5 @@
+(ns runners.doo
+  (:require [doo.runner :refer-macros [doo-all-tests]]
+                                      [runners.tests]))
+
+(doo-all-tests #"(dandy-roll)\..*-test")

--- a/test/runners/tests.cljs
+++ b/test/runners/tests.cljs
@@ -1,0 +1,2 @@
+(ns runners.tests
+  (:require [dandy-roll.core-test]))


### PR DESCRIPTION
Adds a basic test harness for testing via phantomjs and the browser via figwheel/devcards.

Would not have been possible without this [article](https://8thlight.com/blog/eric-smith/2016/10/05/a-testable-clojurescript-setup.html)